### PR TITLE
Tweak paragraph formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13841,11 +13841,6 @@
         "unified": "^8.2.0"
       }
     },
-    "remark-breaks": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-1.0.3.tgz",
-      "integrity": "sha512-ip5hvJE8vsUJCGfgHaEJbf/JfO6KTZV+NBG68AWkEMhrjHW3Qh7EorED41mCt0FFSTrUDeRiNHovKO7cqgPZmw=="
-    },
     "remark-emoji": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "electron-window-state": "^5.0.3",
     "esm": "^3.2.25",
     "promise-waitlist": "^1.5.0",
-    "remark-breaks": "^1.0.3",
     "sodium-universal": "^2.0.0"
   },
   "scripts": {

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -120,12 +120,13 @@ function Compose(props) {
       return;
     }
 
+    e.preventDefault();
+
     // [shift]+enter
     if (e.shiftKey) {
+      setMessage(message + '  \n');
       return;
     }
-
-    e.preventDefault();
 
     // Empty message is not allowed
     if (!message) {

--- a/src/components/Message.css
+++ b/src/components/Message.css
@@ -3,7 +3,7 @@
   margin-bottom: 0.25rem;
   padding: 0.25rem;
 
-  line-height: 1.5rem;
+  line-height: 1.7rem;
 }
 
 .message .message-time-container {
@@ -37,7 +37,16 @@
 }
 
 .message .message-text > p {
-  margin: 0 0 1em 0;
+  margin: 0;
+  text-indent: 3em;
+}
+
+.message .message-text > p:last-child {
+  margin: 0;
+}
+
+.message .message-text > p:first-child {
+  text-indent: 0;
 }
 
 .message .message-text ol {

--- a/src/components/Message.css
+++ b/src/components/Message.css
@@ -46,6 +46,8 @@
 }
 
 .message .message-text > p:first-child {
+  display: inline;
+  
   text-indent: 0;
 }
 

--- a/src/components/Message.css
+++ b/src/components/Message.css
@@ -37,8 +37,7 @@
 }
 
 .message .message-text > p {
-  margin: 0;
-  display: inline;
+  margin: 0 0 1em 0;
 }
 
 .message .message-text ol {

--- a/src/components/Message.css
+++ b/src/components/Message.css
@@ -3,7 +3,7 @@
   margin-bottom: 0.25rem;
   padding: 0.25rem;
 
-  line-height: 1.7rem;
+  line-height: 1.75rem;
 }
 
 .message .message-time-container {

--- a/src/redux/utils.js
+++ b/src/redux/utils.js
@@ -4,7 +4,6 @@ import moment from 'moment';
 import remark from 'remark';
 import remarkReact from 'remark-react';
 import remarkEmoji from 'remark-emoji';
-import breaks from 'remark-breaks';
 
 import binarySearch from 'binary-search';
 import { prerenderUserName } from '../utils';
@@ -69,7 +68,6 @@ export function enrichMessage(message) {
         a: ExternalLink,
       }
     })
-    .use(breaks)
     .use(remarkEmoji)
     .processSync(message.json.text || '').contents;
 


### PR DESCRIPTION
Addresses https://github.com/peerlinks/peerlinks-desktop/issues/27

I've taken out the remark-breaks module because it can do weird things with pasted text. Instead, I append two spaces at the end of the line, when doing ``shift-enter``, which causes markdown to add a line break.

I also format paragraphs so that they stand out better, making pasted text with paragraphs easier to read.