### PR TITLE
uparrow copies last message to compose

### DIFF
--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -28,13 +28,25 @@ function Compose(props) {
     updateState,
   } = props;
 
-  const { identityKey = null, message = '', usersRecentMessages = [] } = state;
+  const {
+    identityKey = null,
+    message = '',
+    usersRecentMessages = [],
+    recentMessageIndex = -1,
+  } = state;
 
   const setMessage = (newMessage) => {
     if (message === newMessage) {
       return;
     }
     updateState({ channelId, state: { message: newMessage } });
+  };
+
+  const setRecentMessageIndex = (newIndex) => {
+    if (recentMessageIndex === newIndex) {
+      return;
+    }
+    updateState({ channelId, state: { recentMessageIndex: newIndex } });
   };
 
   const getUsersRecentMessages = (identityKey) => {
@@ -47,9 +59,11 @@ function Compose(props) {
 
     const recentMessagesUnchanged =
       usersRecentMessages.length === newRecentMessages.length &&
-      usersRecentMessages.every((urm, index) => newRecentMessages[index] === urm);
+      usersRecentMessages.every(
+        (urm, index) => newRecentMessages[index] === urm
+      );
 
-    if ((identityKey === newIdentityKey) && recentMessagesUnchanged) {
+    if (identityKey === newIdentityKey && recentMessagesUnchanged) {
       return;
     }
 
@@ -60,27 +74,27 @@ function Compose(props) {
   };
 
   const getNextMessage = (code) => {
-    if(!message) {
+    const index = usersRecentMessages.length - 1;
+
+    if (!message) {
       // start with most recent
-      return usersRecentMessages[usersRecentMessages.length - 1];
+      return { message: usersRecentMessages[index], index };
     }
 
-    const recentIndex = usersRecentMessages.findIndex(mt => mt === message);
-
-    if(message && recentIndex !== -1) {
+    if (message && recentMessageIndex !== -1) {
       let nextIndex = 0;
       const length = usersRecentMessages.length;
 
-      if(code === 'ArrowUp') {
-        nextIndex = Math.abs((recentIndex - 1 + length) % length);
+      if (code === 'ArrowUp') {
+        nextIndex = Math.abs((recentMessageIndex - 1 + length) % length);
       }
-      if(code === 'ArrowDown') {
-        nextIndex = Math.abs((recentIndex + 1) % length);
+      if (code === 'ArrowDown') {
+        nextIndex = Math.abs((recentMessageIndex + 1) % length);
       }
 
       const nextMessage = usersRecentMessages[nextIndex];
 
-      return nextMessage;
+      return { message: nextMessage, index: nextIndex };
     }
 
     return null;
@@ -118,7 +132,7 @@ function Compose(props) {
   });
 
   useEffect(() => {
-    const onArrowKeyDown = e => {
+    const onArrowKeyDown = (e) => {
       if (!e.key || e.metaKey || e.ctrlKey) {
         return;
       }
@@ -133,7 +147,8 @@ function Compose(props) {
           const nextMessage = getNextMessage(e.code);
 
           if (nextMessage !== null && nextMessage !== message) {
-            setMessage(nextMessage);
+            setMessage(nextMessage.message);
+            setRecentMessageIndex(nextMessage.index);
           }
         }
         input.current.focus();
@@ -332,6 +347,7 @@ Compose.propTypes = {
     identityKey: PropTypes.string,
     message: PropTypes.string,
     usersRecentMessages: PropTypes.array,
+    recentMessageIndex: PropTypes.number,
   }),
 
   postMessage: PropTypes.func.isRequired,

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -30,6 +30,8 @@ function Compose(props) {
 
   const { identityKey = null, message = '', usersRecentMessages = [] } = state;
 
+  const RECENT_MESSAGES_LIMIT = 10;
+
   const setMessage = (newMessage) => {
     if (message === newMessage) {
       return;
@@ -38,11 +40,23 @@ function Compose(props) {
   };
 
   const getRecentMessages = (identityKey) => {
-    return messages.filter(
-      m =>
-        !m.isRoot &&
-        m.author.publicKeys.some(pubKey => pubKey === identityKey)
-    );
+    const recentMessages = [];
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+
+      if(!message.isRoot && message.author.publicKeys.some(pubKey => pubKey === identityKey)) {
+        const newLength = recentMessages.push(message);
+
+        if(newLength === RECENT_MESSAGES_LIMIT) {
+          break;
+        }
+      }
+    }
+
+    recentMessages.reverse();
+
+    return recentMessages;
   };
 
   const setUsersRecentMessages = (newIdentityKey) => {

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -74,14 +74,16 @@ function Compose(props) {
   };
 
   const getNextMessage = (code) => {
-    const index = usersRecentMessages.length - 1;
+    const startIndex = usersRecentMessages.length - 1;
 
     if (!message) {
       // start with most recent
-      return { message: usersRecentMessages[index], index };
+      return { message: usersRecentMessages[startIndex], index: startIndex };
     }
 
-    if (message && recentMessageIndex !== -1) {
+    const indexInHistory = usersRecentMessages.findIndex(urm => urm === message);
+
+    if (message && recentMessageIndex !== -1 && indexInHistory !== -1) {
       let nextIndex = 0;
       const length = usersRecentMessages.length;
 

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -66,8 +66,16 @@ function Compose(props) {
     const recentIndex = usersRecentMessages.findIndex(urm => urm.json.text === message);
 
     if(message && recentIndex !== -1) {
-      const incrementAmount = { ArrowUp: -1, ArrowDown: 1 };
-      const nextIndex = Math.abs((recentIndex + incrementAmount[code]) % usersRecentMessages.length);
+      let nextIndex = 0;
+      const length = usersRecentMessages.length;
+
+      if(code === 'ArrowUp') {
+        nextIndex = Math.abs((recentIndex - 1 + length) % length);
+      }
+      if(code === 'ArrowDown') {
+        nextIndex = Math.abs((recentIndex + 1) % length);
+      }
+
       const nextMessage = usersRecentMessages[nextIndex].json.text;
 
       return nextMessage;

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -22,6 +22,7 @@ function Compose(props) {
     onBeforePost,
     postFile,
     addNotification,
+    lastMessageText,
 
     state,
     updateState,
@@ -46,12 +47,16 @@ function Compose(props) {
   const input = useRef();
 
   useEffect(() => {
-    const onKeyDown = (e) => {
+    const onKeyDown = e => {
       if (!e.key || e.metaKey || e.ctrlKey) {
         return;
       }
 
       if (input.current && !isPickerVisible) {
+        // don't overwrite if something already typed
+        if (e.keyCode === 38 && !message) {
+          setMessage(lastMessageText);
+        }
         input.current.focus();
       }
     };
@@ -238,6 +243,7 @@ function Compose(props) {
 Compose.propTypes = {
   identities: PropTypes.array.isRequired,
   channelId: PropTypes.string.isRequired,
+  lastMessageText: PropTypes.string,
 
   state: PropTypes.exact({
     identityKey: PropTypes.string,

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -107,17 +107,19 @@ function Compose(props) {
       }
 
       // if the user selects a different identity, the focus will be on the select
-      // this is used to allow up/down to cycle through identities
+      // this is used to allow up/down to cycle through identities if the focus is on select
       const isSelect = e.target.nodeName === 'SELECT';
 
-      // this is used to preserve non up/down keys to bring focus to textarea
       const isUpOrDown = e.code === 'ArrowUp' || e.code === 'ArrowDown';
 
       if (input.current && !isPickerVisible) {
         if (!isSelect) {
           const areMessages = usersRecentMessages.length > 0;
 
-          if (areMessages &&  isUpOrDown && !isSelect) {
+          // so only the up key starts the cycle through recent messages
+          const keyDownNoMessage = (!message && e.code === 'ArrowDown');
+
+          if (areMessages &&  isUpOrDown && !isSelect && !keyDownNoMessage) {
             const nextMessage = getNextMessage(e.code);
 
             if(nextMessage !== null && nextMessage !== message) {
@@ -125,7 +127,7 @@ function Compose(props) {
             }
           }
           input.current.focus();
-        } else if(isSelect && !isUpOrDown) {
+        } else if(isSelect && !isUpOrDown) { // so non up/down keys bring focus to textarea
           input.current.focus();
         }
       }

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -62,8 +62,9 @@ function Compose(props) {
   const setUsersRecentMessages = (newIdentityKey) => {
     const newRecentMessages = getUsersRecentMessages(newIdentityKey);
 
-    const recentMessagesUnchanged = usersRecentMessages
-      .every((urm, index) => newRecentMessages[index].json.text === urm.json.text);
+    const recentMessagesUnchanged =
+      usersRecentMessages.length === newRecentMessages.length &&
+      usersRecentMessages.every((urm, index) => newRecentMessages[index].json.text === urm.json.text);
 
     if ((identityKey === newIdentityKey) && recentMessagesUnchanged) {
       return;
@@ -113,11 +114,9 @@ function Compose(props) {
       return;
     }
 
-    const usersRecentMessages = getUsersRecentMessages(newIdentityKey);
-
     updateState({
       channelId,
-      state: { identityKey: newIdentityKey, usersRecentMessages },
+      state: { identityKey: newIdentityKey },
     });
   };
 

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -39,7 +39,7 @@ function Compose(props) {
     updateState({ channelId, state: { message: newMessage } });
   };
 
-  const getRecentMessages = (identityKey) => {
+  const getUsersRecentMessages = (identityKey) => {
     const recentMessages = [];
 
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -60,15 +60,18 @@ function Compose(props) {
   };
 
   const setUsersRecentMessages = (newIdentityKey) => {
-    if (identityKey === newIdentityKey) {
+    const newRecentMessages = getUsersRecentMessages(newIdentityKey);
+
+    const recentMessagesUnchanged = usersRecentMessages
+      .every((urm, index) => newRecentMessages[index].json.text === urm.json.text);
+
+    if ((identityKey === newIdentityKey) && recentMessagesUnchanged) {
       return;
     }
 
-    const usersRecentMessages = getRecentMessages(newIdentityKey);
-
     updateState({
       channelId,
-      state: { usersRecentMessages },
+      state: { usersRecentMessages: newRecentMessages },
     });
   };
 
@@ -110,7 +113,7 @@ function Compose(props) {
       return;
     }
 
-    const usersRecentMessages = getRecentMessages(newIdentityKey);
+    const usersRecentMessages = getUsersRecentMessages(newIdentityKey);
 
     updateState({
       channelId,

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -73,15 +73,22 @@ function Compose(props) {
   };
 
   const getNextMessage = (code) => {
+    // remove duplicates, better for ux, won't look like value is not updating
+    // also simpler logic handling next message
+    const messageTexts = [
+      ...new Set(usersRecentMessages.map(urm => urm.json.text)),
+    ];
+
     if(!message) {
-      return usersRecentMessages[usersRecentMessages.length - 1].json.text;
+      // start with most recent
+      return messageTexts[messageTexts.length - 1];
     }
 
-    const recentIndex = usersRecentMessages.findIndex(urm => urm.json.text === message);
+    const recentIndex = messageTexts.findIndex(mt => mt === message);
 
     if(message && recentIndex !== -1) {
       let nextIndex = 0;
-      const length = usersRecentMessages.length;
+      const length = messageTexts.length;
 
       if(code === 'ArrowUp') {
         nextIndex = Math.abs((recentIndex - 1 + length) % length);
@@ -90,7 +97,7 @@ function Compose(props) {
         nextIndex = Math.abs((recentIndex + 1) % length);
       }
 
-      const nextMessage = usersRecentMessages[nextIndex].json.text;
+      const nextMessage = messageTexts[nextIndex];
 
       return nextMessage;
     }

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -47,14 +47,14 @@ function Compose(props) {
   const input = useRef();
 
   useEffect(() => {
-    const onKeyDown = e => {
+    const onKeyDown = (e) => {
       if (!e.key || e.metaKey || e.ctrlKey) {
         return;
       }
 
       if (input.current && !isPickerVisible) {
         // don't overwrite if something already typed
-        if (e.keyCode === 38 && !message) {
+        if (e.code === 'ArrowUp' && !message) {
           setMessage(lastMessageText);
         }
         input.current.focus();

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -129,36 +129,43 @@ function Compose(props) {
         return;
       }
 
-      // if the user selects a different identity, the focus will be on the select
-      // this is used to allow up/down to cycle through identities if the focus is on select
-      const isSelect = e.target.nodeName === 'SELECT';
-
-      const isUpOrDown = e.code === 'ArrowUp' || e.code === 'ArrowDown';
-
       if (input.current && !isPickerVisible) {
-        if (!isSelect) {
-          const areMessages = usersRecentMessages.length > 0;
-
-          // so only the up key starts the cycle through recent messages
-          const keyDownNoMessage = (!message && e.code === 'ArrowDown');
-
-          if (areMessages &&  isUpOrDown && !isSelect && !keyDownNoMessage) {
-            const nextMessage = getNextMessage(e.code);
-
-            if(nextMessage !== null && nextMessage !== message) {
-              setMessage(nextMessage);
-            }
-          }
-          input.current.focus();
-        } else if(isSelect && !isUpOrDown) { // so non up/down keys bring focus to textarea
-          input.current.focus();
-        }
+        input.current.focus();
       }
     };
     document.addEventListener('keydown', onKeyDown);
 
     return () => {
       document.removeEventListener('keydown', onKeyDown);
+    };
+  });
+
+  useEffect(() => {
+    const onArrowKeyDown = e => {
+      if (!e.key || e.metaKey || e.ctrlKey) {
+        return;
+      }
+
+      if (input.current && !isPickerVisible) {
+        const areMessages = usersRecentMessages.length > 0;
+
+        // so only the up key/no message starts the cycle through recent messages
+        const keyDownNoMessage = !message && e.code === 'ArrowDown';
+
+        if (areMessages && !keyDownNoMessage) {
+          const nextMessage = getNextMessage(e.code);
+
+          if (nextMessage !== null && nextMessage !== message) {
+            setMessage(nextMessage);
+          }
+        }
+        input.current.focus();
+      }
+    };
+    input.current.addEventListener('keydown', onArrowKeyDown);
+
+    return () => {
+      input.current.removeEventListener('keydown', onArrowKeyDown);
     };
   });
 

--- a/src/pages/Channel.js
+++ b/src/pages/Channel.js
@@ -168,7 +168,7 @@ function Channel(props) {
       </div>
     </div>
     <footer className='channel-compose'>
-      <Compose channelId={channelId} onBeforePost={onBeforePost} />
+      <Compose channelId={channelId} onBeforePost={onBeforePost}/>
     </footer>
   </div>;
 }

--- a/src/pages/Channel.js
+++ b/src/pages/Channel.js
@@ -129,6 +129,12 @@ function Channel(props) {
     </span>;
   }
 
+  let lastMessage = channel.messages[channel.messages.length - 1];
+  let lastMessageText = '';
+  if(lastMessage && lastMessage.json) {
+    lastMessageText = lastMessage.json.text;
+  }
+
   return <div className='channel-container'>
     <header className='channel-info'>
       <div className='channel-info-container'>
@@ -168,7 +174,7 @@ function Channel(props) {
       </div>
     </div>
     <footer className='channel-compose'>
-      <Compose channelId={channelId} onBeforePost={onBeforePost}/>
+      <Compose channelId={channelId} onBeforePost={onBeforePost} lastMessageText={lastMessageText}/>
     </footer>
   </div>;
 }

--- a/src/pages/Channel.js
+++ b/src/pages/Channel.js
@@ -129,12 +129,6 @@ function Channel(props) {
     </span>;
   }
 
-  let lastMessage = channel.messages[channel.messages.length - 1];
-  let lastMessageText = '';
-  if(lastMessage && lastMessage.json) {
-    lastMessageText = lastMessage.json.text;
-  }
-
   return <div className='channel-container'>
     <header className='channel-info'>
       <div className='channel-info-container'>
@@ -174,7 +168,7 @@ function Channel(props) {
       </div>
     </div>
     <footer className='channel-compose'>
-      <Compose channelId={channelId} onBeforePost={onBeforePost} lastMessageText={lastMessageText}/>
+      <Compose channelId={channelId} onBeforePost={onBeforePost} />
     </footer>
   </div>;
 }

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -38,6 +38,7 @@ export const CHANNEL_SET_MESSAGE_COUNT = 'CHANNEL_SET_MESSAGE_COUNT';
 export const CHANNEL_UPDATE_METADATA = 'CHANNEL_UPDATE_METADATA';
 export const CHANNEL_UPDATE_READ_HEIGHT = 'CHANNEL_UPDATE_READ_HEIGHT';
 export const CHANNEL_SET_CHAIN_MAP = 'CHANNEL_SET_CHAIN_MAP';
+export const CHANNEL_PUSH_TO_HISTORY = 'CHANNEL_PUSH_TO_HISTORY';
 
 const network = new Network();
 
@@ -405,6 +406,10 @@ export function updateChannelMetadata({ channelId, metadata }) {
 
 export function appendChannelMessage({ channelId, message, isPosted = false }) {
   return { type: APPEND_CHANNEL_MESSAGE, channelId, message, isPosted };
+}
+
+export function updateChannelHistory({ channelId, identityKey, message }) {
+  return { type: CHANNEL_PUSH_TO_HISTORY, channelId, identityKey, message };
 }
 
 export function appendInternalMessage({ channelId, text }) {
@@ -837,6 +842,13 @@ export function postMessage({ channelId, identityKey, text }) {
     });
 
     dispatch(appendChannelMessage({ channelId, message, isPosted: true }));
+    dispatch(
+      updateChannelHistory({
+        channelId,
+        identityKey,
+        message: message.json.text,
+      })
+    );
   };
 
   return (dispatch) => {

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -474,7 +474,7 @@ export const channels = (state = new Map(), action) => {
       const history = new Map(channel.history);
       const identityMessages = history.get(action.identityKey);
 
-      if(identityMessages) {
+      if (identityMessages) {
         history.set(action.identityKey, [ ...identityMessages, action.message ]);
       } else {
         history.set(action.identityKey, [ action.message ]);

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -23,7 +23,7 @@ import {
 
   ADD_CHANNEL, REMOVE_CHANNEL, APPEND_CHANNEL_MESSAGE, APPEND_CHANNEL_MESSAGES,
   TRIM_CHANNEL_MESSAGES, CHANNEL_SET_MESSAGE_COUNT, CHANNEL_UPDATE_METADATA,
-  CHANNEL_UPDATE_READ_HEIGHT, CHANNEL_SET_CHAIN_MAP,
+  CHANNEL_UPDATE_READ_HEIGHT, CHANNEL_SET_CHAIN_MAP, CHANNEL_PUSH_TO_HISTORY,
 
   RENAME_IDENTITY_PAIR,
 } from './actions';
@@ -336,6 +336,8 @@ export const channels = (state = new Map(), action) => {
           // NOTE: See CHANNEL_SET_CHAIN_MAP below
           activeUsers: [],
 
+          history: channel.history,
+
           // NOTE: Do not update channel messages
           messages: channel.messages,
         };
@@ -348,6 +350,8 @@ export const channels = (state = new Map(), action) => {
 
       // NOTE: See CHANNEL_SET_CHAIN_MAP below
       activeUsers: [],
+
+      history: new Map(),
 
       // Start in all-read state
       messagesRead: action.channel.messageCount,
@@ -464,6 +468,23 @@ export const channels = (state = new Map(), action) => {
     }
 
     return copy;
+  }
+  case CHANNEL_PUSH_TO_HISTORY: {
+    return updateChannel(state, action, (channel) => {
+      const history = new Map(channel.history);
+      const identityMessages = history.get(action.identityKey);
+
+      if(identityMessages) {
+        history.set(action.identityKey, [ ...identityMessages, action.message ]);
+      } else {
+        history.set(action.identityKey, [ action.message ]);
+      }
+
+      return {
+        ...channel,
+        history,
+      };
+    });
   }
   default:
     return state;


### PR DESCRIPTION
Behaviour:

- ArrowUp: begins cycling through the 10 most recent messages if there are any. Pressing ArrowUp/ArrowDown once this has started cycles through recent messages, it will wrap around once you hit the last element in each direction.

- ArrowUp/ArrowDown (when the focus is on the identities select dropdown, after changing an identity, for example): toggles the identities, pressing any other key from here will bring the focus to the text box. I believe this is expected default behaviour? I can change this if not.

- ArrowDown (when the focus is anywhre other than the identities select dropdown): brings the focus to the text box.

Note:
Currently messages that have identical text are filtered out. This was better UX when the identical messages were one after the other as it appears the message is not updating. 

closes #20 