### PR TITLE
Fix empty select after deleting identity

### DIFF
--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -89,12 +89,12 @@ function Compose(props) {
       label={identity.name}/>;
   });
 
-  const keyFromDeletedIdentity = identities.every(
-    (identity) => identity.publicKey !== identityKey
+  const keyPresent = identities.some(
+    (identity) => identity.publicKey === identityKey
   );
 
   // Select first identity
-  if (!identityKey || keyFromDeletedIdentity) {
+  if (!identityKey || !keyPresent) {
     setIdentityKey(identities[0].publicKey);
   }
 

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -89,8 +89,12 @@ function Compose(props) {
       label={identity.name}/>;
   });
 
+  const keyFromDeletedIdentity = identities.every(
+    identity => identity.publicKey !== identityKey
+  );
+
   // Select first identity
-  if (!identityKey) {
+  if (!identityKey || keyFromDeletedIdentity) {
     setIdentityKey(identities[0].publicKey);
   }
 

--- a/src/components/Compose.js
+++ b/src/components/Compose.js
@@ -90,7 +90,7 @@ function Compose(props) {
   });
 
   const keyFromDeletedIdentity = identities.every(
-    identity => identity.publicKey !== identityKey
+    (identity) => identity.publicKey !== identityKey
   );
 
   // Select first identity


### PR DESCRIPTION
Added check to see if selected identity key belongs to a deleted identity, if so, select the first identity in the identities list ( just like when component first rendered).

Fixes: #23